### PR TITLE
Added semantic battery icon aliases

### DIFF
--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -604,12 +604,16 @@
 .#{$fa-css-prefix}-opencart:before { content: $fa-var-opencart; }
 .#{$fa-css-prefix}-expeditedssl:before { content: $fa-var-expeditedssl; }
 .#{$fa-css-prefix}-battery-4:before,
+.#{$fa-css-prefix}-battery-100:before,
 .#{$fa-css-prefix}-battery-full:before { content: $fa-var-battery-full; }
 .#{$fa-css-prefix}-battery-3:before,
+.#{$fa-css-prefix}-battery-75:before,
 .#{$fa-css-prefix}-battery-three-quarters:before { content: $fa-var-battery-three-quarters; }
 .#{$fa-css-prefix}-battery-2:before,
+.#{$fa-css-prefix}-battery-50:before,
 .#{$fa-css-prefix}-battery-half:before { content: $fa-var-battery-half; }
 .#{$fa-css-prefix}-battery-1:before,
+.#{$fa-css-prefix}-battery-25:before,
 .#{$fa-css-prefix}-battery-quarter:before { content: $fa-var-battery-quarter; }
 .#{$fa-css-prefix}-battery-0:before,
 .#{$fa-css-prefix}-battery-empty:before { content: $fa-var-battery-empty; }


### PR DESCRIPTION
Instead of using frame numbers to choose which icon, semantically name the aliases to relate to battery level using numbers so class names can be generated without a class dictionary
